### PR TITLE
Error reporting

### DIFF
--- a/admin-bot/src/main/kotlin/com/github/heheteam/adminbot/AdminRunner.kt
+++ b/admin-bot/src/main/kotlin/com/github/heheteam/adminbot/AdminRunner.kt
@@ -39,6 +39,7 @@ import com.github.heheteam.commonlib.util.NewState
 import com.github.heheteam.commonlib.util.Unhandled
 import com.github.heheteam.commonlib.util.UpdateHandlersController
 import com.github.heheteam.commonlib.util.startStateOnUnhandledUpdate
+import com.github.michaelbull.result.get
 import dev.inmo.kslog.common.KSLog
 import dev.inmo.kslog.common.error
 import dev.inmo.micro_utils.coroutines.subscribeSafelyWithoutExceptions
@@ -50,9 +51,14 @@ import dev.inmo.tgbotapi.extensions.behaviour_builder.DefaultBehaviourContextWit
 import dev.inmo.tgbotapi.extensions.behaviour_builder.telegramBotWithBehaviourAndFSMAndStartLongPolling
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.command
 import dev.inmo.tgbotapi.extensions.utils.extensions.raw.from
+import dev.inmo.tgbotapi.extensions.utils.groupChatOrNull
 import dev.inmo.tgbotapi.types.BotCommand
 import dev.inmo.tgbotapi.types.chat.User
+import dev.inmo.tgbotapi.types.message.content.TextMessage
+import dev.inmo.tgbotapi.types.toChatId
 import dev.inmo.tgbotapi.utils.RiskFeature
+import dev.inmo.tgbotapi.utils.buildEntities
+import dev.inmo.tgbotapi.utils.code
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.datetime.LocalDateTime
@@ -93,6 +99,8 @@ class AdminRunner(private val adminApi: AdminApi) {
           val user = it.from
           if (user != null) startChain(StartState(user))
         }
+        command("bind") { tryBindingChatToErrorService(it) }
+
         startStateOnUnhandledUpdate { user ->
           if (user != null) startChain(MenuState(user, DEFAULT_ADMIN_ID.toAdminId()))
         }
@@ -103,6 +111,26 @@ class AdminRunner(private val adminApi: AdminApi) {
       }
       .second
       .join()
+  }
+
+  @OptIn(RiskFeature::class)
+  private suspend fun DefaultBehaviourContextWithFSM<State>.tryBindingChatToErrorService(
+    message: TextMessage
+  ) {
+    val chat = message.chat.groupChatOrNull()
+    if (chat != null) {
+      val user = message.from
+      if (user != null && adminApi.tgIdIsInWhitelist(user.id).get() ?: false) {
+        adminApi.bindErrorChat(chat.id.toChatId().chatId)
+        bot.send(chat, "bound successfully")
+      } else {
+        val text = buildEntities {
+          +"No authorized; your id: "
+          code(user?.id.toString())
+        }
+        bot.send(chat, text)
+      }
+    }
   }
 
   private fun DefaultBehaviourContextWithFSM<State>.registerAllStates() {

--- a/common-lib/src/main/kotlin/com/github/heheteam/commonlib/api/AdminApi.kt
+++ b/common-lib/src/main/kotlin/com/github/heheteam/commonlib/api/AdminApi.kt
@@ -32,6 +32,7 @@ import com.github.heheteam.commonlib.logic.ScheduledMessageService
 import com.github.heheteam.commonlib.util.toUrl
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
+import dev.inmo.tgbotapi.types.RawChatId
 import dev.inmo.tgbotapi.types.UserId
 import java.time.LocalDateTime
 
@@ -228,4 +229,8 @@ internal constructor(
   fun getTokenForCourse(courseId: CourseId): String? = tokenStorage.getTokenForCourse(courseId)
 
   fun regenerateTokenForCourse(courseId: CourseId): String = tokenStorage.regenerateToken(courseId)
+
+  fun bindErrorChat(id: RawChatId) {
+    errorManagementService.boundChat = id
+  }
 }

--- a/common-lib/src/main/kotlin/com/github/heheteam/commonlib/api/ApiFabric.kt
+++ b/common-lib/src/main/kotlin/com/github/heheteam/commonlib/api/ApiFabric.kt
@@ -214,7 +214,7 @@ class ApiFabric(
         botEventBus,
       )
 
-    val errorManagementService = ErrorManagementService()
+    val errorManagementService = ErrorManagementService(adminBotTelegramController)
 
     val studentApi =
       StudentApi(

--- a/common-lib/src/main/kotlin/com/github/heheteam/commonlib/errors/ErrorManagementService.kt
+++ b/common-lib/src/main/kotlin/com/github/heheteam/commonlib/errors/ErrorManagementService.kt
@@ -1,20 +1,27 @@
 package com.github.heheteam.commonlib.errors
 
+import com.github.heheteam.commonlib.telegram.AdminBotTelegramController
 import com.github.michaelbull.result.BindingScope
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.coroutines.CoroutineBindingScope
 import com.github.michaelbull.result.coroutines.coroutineBinding
+import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.mapError
 import dev.inmo.kslog.common.KSLog
 import dev.inmo.kslog.common.error
+import dev.inmo.tgbotapi.types.RawChatId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
-class ErrorManagementService {
+class ErrorManagementService(val adminBotController: AdminBotTelegramController) {
   private companion object ErrorCounter {
     private var currentErrorNumber: Long = 1
 
     fun newErrorNumber(): Long = currentErrorNumber++
   }
+
+  var boundChat: RawChatId? = null
 
   private fun EduPlatformError.toNumberedError(): NumberedError {
     val errorNumber = newErrorNumber()
@@ -30,8 +37,17 @@ class ErrorManagementService {
   private fun <U> Result<U, EduPlatformError>.toNumberedError(): Result<U, NumberedError> =
     this.mapError { it.toNumberedError() }
 
-  fun <V> serviceBinding(block: BindingScope<EduPlatformError>.() -> V): Result<V, NumberedError> =
-    binding(block).toNumberedError()
+  fun <V> serviceBinding(block: BindingScope<EduPlatformError>.() -> V): Result<V, NumberedError> {
+    val result = binding(block).toNumberedError()
+    val error = result.getError()
+    if (error != null) {
+      val boundChat = boundChat
+      if (boundChat != null) {
+        runBlocking(Dispatchers.IO) { adminBotController.sendErrorInfo(boundChat, error) }
+      }
+    }
+    return result
+  }
 
   suspend fun <V> coroutineServiceBinding(
     block: suspend CoroutineBindingScope<EduPlatformError>.() -> V

--- a/common-lib/src/main/kotlin/com/github/heheteam/commonlib/telegram/AdminBotTelegramController.kt
+++ b/common-lib/src/main/kotlin/com/github/heheteam/commonlib/telegram/AdminBotTelegramController.kt
@@ -1,6 +1,7 @@
 package com.github.heheteam.commonlib.telegram
 
 import com.github.heheteam.commonlib.errors.EduPlatformError
+import com.github.heheteam.commonlib.errors.NumberedError
 import com.github.heheteam.commonlib.interfaces.StudentId
 import com.github.michaelbull.result.Result
 import dev.inmo.tgbotapi.types.RawChatId
@@ -12,4 +13,6 @@ interface AdminBotTelegramController {
     studentId: StudentId,
     newDeadline: LocalDateTime,
   ): Result<Unit, EduPlatformError>
+
+  suspend fun sendErrorInfo(chatId: RawChatId, error: NumberedError)
 }

--- a/common-lib/src/main/kotlin/com/github/heheteam/commonlib/telegram/AdminBotTelegramControllerImpl.kt
+++ b/common-lib/src/main/kotlin/com/github/heheteam/commonlib/telegram/AdminBotTelegramControllerImpl.kt
@@ -1,7 +1,9 @@
 package com.github.heheteam.commonlib.telegram
 
 import com.github.heheteam.commonlib.errors.EduPlatformError
+import com.github.heheteam.commonlib.errors.NumberedError
 import com.github.heheteam.commonlib.errors.asEduPlatformError
+import com.github.heheteam.commonlib.errors.toStackedString
 import com.github.heheteam.commonlib.interfaces.StudentId
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.map
@@ -12,6 +14,9 @@ import dev.inmo.tgbotapi.extensions.utils.types.buttons.dataButton
 import dev.inmo.tgbotapi.extensions.utils.types.buttons.inlineKeyboard
 import dev.inmo.tgbotapi.types.RawChatId
 import dev.inmo.tgbotapi.types.toChatId
+import dev.inmo.tgbotapi.utils.boldln
+import dev.inmo.tgbotapi.utils.buildEntities
+import dev.inmo.tgbotapi.utils.regularln
 import dev.inmo.tgbotapi.utils.row
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -38,6 +43,15 @@ class AdminBotTelegramControllerImpl(val adminBot: TelegramBot) : AdminBotTelegr
       }
       .mapError { it.asEduPlatformError(AdminBotTelegramControllerImpl::class) }
       .map {}
+
+  override suspend fun sendErrorInfo(chatId: RawChatId, error: NumberedError) {
+    val errorText = error.error.toStackedString()
+    val errorMessage = buildEntities {
+      boldln("Ошибка №:${error.number}")
+      regularln(errorText)
+    }
+    adminBot.send(chatId.toChatId(), errorMessage)
+  }
 
   private fun moveDeadlines(studentId: StudentId, newDeadline: LocalDateTime) = inlineKeyboard {
     row {

--- a/common-lib/src/main/kotlin/com/github/heheteam/commonlib/util/TelegramUtil.kt
+++ b/common-lib/src/main/kotlin/com/github/heheteam/commonlib/util/TelegramUtil.kt
@@ -10,6 +10,8 @@ import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onDataCa
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onMessageCallbackQuery
 import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onUnhandledCommand
 import dev.inmo.tgbotapi.extensions.utils.extensions.raw.from
+import dev.inmo.tgbotapi.extensions.utils.extensions.raw.message
+import dev.inmo.tgbotapi.extensions.utils.groupChatOrNull
 import dev.inmo.tgbotapi.types.chat.User
 import dev.inmo.tgbotapi.types.message.abstracts.AccessibleMessage
 import dev.inmo.tgbotapi.types.message.abstracts.ContentMessage
@@ -41,8 +43,8 @@ suspend fun BehaviourContext.delete(vararg messages: AccessibleMessage) {
 
 @OptIn(RiskFeature::class, PreviewFeature::class)
 suspend fun BehaviourContext.startStateOnUnhandledUpdate(handleAction: suspend (User?) -> Unit) {
-  onUnhandledCommand { handleAction(it.from) }
-  onMessageCallbackQuery { handleAction(it.from) }
-  onDataCallbackQuery { handleAction(it.from) }
-  onContentMessage { handleAction(it.from) }
+  onUnhandledCommand { if (it.chat.groupChatOrNull() == null) handleAction(it.from) }
+  onMessageCallbackQuery { if (it.message.chat.groupChatOrNull() == null) handleAction(it.from) }
+  onDataCallbackQuery { if (it.message?.chat?.groupChatOrNull() == null) handleAction(it.from) }
+  onContentMessage { if (it.chat.groupChatOrNull() == null) handleAction(it.from) }
 }

--- a/common-lib/src/test/kotlin/com/github/heheteam/commonlib/adminbot/AdminBotTest.kt
+++ b/common-lib/src/test/kotlin/com/github/heheteam/commonlib/adminbot/AdminBotTest.kt
@@ -18,6 +18,7 @@ import com.github.heheteam.commonlib.logic.AdminAuthService
 import com.github.heheteam.commonlib.logic.CourseTokenService
 import com.github.heheteam.commonlib.logic.PersonalDeadlinesService
 import com.github.heheteam.commonlib.logic.ScheduledMessageService
+import com.github.heheteam.commonlib.telegram.AdminBotTelegramController
 import com.github.heheteam.commonlib.telegram.StudentBotTelegramController
 import io.mockk.mockk
 import kotlin.test.AfterTest
@@ -36,6 +37,7 @@ class AdminBotTest {
     )
   private val core: AdminApi
   private val studentBotController = mockk<StudentBotTelegramController>(relaxed = true)
+  private val adminBotController = mockk<AdminBotTelegramController>(relaxed = true)
 
   init {
     val problemStorage = DatabaseProblemStorage(database)
@@ -57,7 +59,7 @@ class AdminBotTest {
         DatabaseSubmissionDistributor(database),
         mockk<PersonalDeadlinesService>(relaxed = true),
         mockk<CourseTokenService>(relaxed = true),
-        ErrorManagementService(),
+        ErrorManagementService(adminBotController),
         mockk<CourseService>(relaxed = true),
       )
   }

--- a/common-lib/src/test/kotlin/com/github/heheteam/commonlib/studentbot/StudentBotTest.kt
+++ b/common-lib/src/test/kotlin/com/github/heheteam/commonlib/studentbot/StudentBotTest.kt
@@ -29,6 +29,7 @@ import com.github.heheteam.commonlib.logic.ScheduledMessageService
 import com.github.heheteam.commonlib.logic.StudentViewService
 import com.github.heheteam.commonlib.logic.ui.NewSubmissionTeacherNotifier
 import com.github.heheteam.commonlib.logic.ui.UiController
+import com.github.heheteam.commonlib.telegram.AdminBotTelegramController
 import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -70,6 +71,7 @@ class StudentBotTest {
     val mockPersonalDeadlinesService = mockk<PersonalDeadlinesService>(relaxed = true)
     val mockCourseTokensService = mockk<CourseTokenService>(relaxed = true)
     val teacherNotifier = mockk<NewSubmissionTeacherNotifier>()
+    val adminBotController = mockk<AdminBotTelegramController>(relaxed = true)
     academicWorkflowService =
       AcademicWorkflowService(
         academicWorkflowLogic,
@@ -90,7 +92,7 @@ class StudentBotTest {
         StudentViewService(courseStorage, problemStorage, assignmentStorage),
         studentStorage,
         mockCourseTokensService,
-        ErrorManagementService(),
+        ErrorManagementService(adminBotController),
       )
   }
 


### PR DESCRIPTION
To subscribe to error reporting, write /bind in a group chat with an admin bot. Currently only one chat is supported. I suspect really poor code quality, but i cannot be sure. Please roast the code. To simulate an error, add ``raiseError(NamedError("get all course error", null, NamedError("Parent thing")))`` somewhere within `serviceBinding { ... }`.